### PR TITLE
Fix: Auto aria-levels (Issue #1)

### DIFF
--- a/templates/lens.jsx
+++ b/templates/lens.jsx
@@ -13,7 +13,7 @@ export default function Lens (props) {
     _ariaLevel,
     onChange
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) ? _ariaLevel + 1 : _ariaLevel;
+  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 ? _ariaLevel + 1 : _ariaLevel;
   const itemActive = _items.find(item => item._isActive);
 
   return (


### PR DESCRIPTION
Fixes issue #1.

Only likely to occur when courses are exported from the Adapt Authoring tool.

Occurs when _ariaLevel exists and is the default value. Affects subheadings in component (when override exists and set to 0(zero)